### PR TITLE
Cambios para la compilacion de Mac

### DIFF
--- a/src/qt/src/tools/qglobal.h
+++ b/src/qt/src/tools/qglobal.h
@@ -186,7 +186,10 @@
 #  if !defined(MAC_OS_X_VERSION_10_5)
 #       define MAC_OS_X_VERSION_10_5 MAC_OS_X_VERSION_10_4 + 1
 #  endif
-#  if (MAC_OS_X_VERSION_MAX_ALLOWED > MAC_OS_X_VERSION_10_5)
+#  if !defined(MAC_OS_X_VERSION_10_6)
+#       define MAC_OS_X_VERSION_10_6 MAC_OS_X_VERSION_10_5 + 1
+#  endif
+#  if (MAC_OS_X_VERSION_MAX_ALLOWED > MAC_OS_X_VERSION_10_6)
 #    error "This version of Mac OS X is unsupported"
 #  endif
 #endif


### PR DESCRIPTION
Simplemente, QT no te permite compilar por unos defines si lo intentas desde la 10.6. Si los modificas para que la permitan, compila perfectamente, así que no hay problema.
